### PR TITLE
fix: Use image version tag in docker-compose

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
 
   ttpx-web:
-    image: ghcr.io/initstring/ttpx:main
+    image: ghcr.io/initstring/ttpx:v0.1.0
     container_name: ttpx-web
     depends_on:
       - ttpx-postgres


### PR DESCRIPTION
This uses a static tag in the docker-compose file, which should be updated before tagging a new release.