### PR TITLE
feat: Clarify GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,22 @@
+name: Validate Docker Build
+
+on:
+  pull_request:
+
+jobs:
+  validate-docker-build:
+    name: Build Docker Image (no push)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,8 +1,6 @@
-name: Build and Push Docker Image
+name: Publish Docker Image
 
 on:
-  pull_request:
-    branches: [ main ]
   release:
     # Publishing a release for an existing tag (via the GitHub UI) does not
     # emit a push event, so include this trigger to build the image when a
@@ -10,25 +8,8 @@ on:
     types: [ published ]
 
 jobs:
-  docker-build-pr:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build image (no push)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: deploy/docker/Dockerfile
-          push: false
-
-  docker:
-    if: github.event_name == 'release'
+  publish:
+    name: Publish Docker Image to GHCR
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,7 +36,7 @@ jobs:
           tags: |
             type=ref,event=tag
 
-      - name: Build and push
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary

- Run the CI workflow on every PR (regardless of target branch) so linting, type-checking, tests, and build validation always execute.
- Rename and split the Docker automation into two workflows: PRs now use “Validate Docker Build” (build-only), while releases use “Publish Docker Image” with explicit GHCR push wording.

## Testing

- Workflow definition lint via act -l (optional).
- CI will validate on next PR; release workflow remains unchanged functionally aside from naming.