### PR TITLE
Silence experimental webauthn warning

### DIFF
--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -175,6 +175,8 @@ export const authConfig = {
       logger.error(payload, "Auth.js error");
     },
     warn(code) {
+      if (code === "experimental-webauthn") return;
+
       logger.warn({ event: "authjs.warn", code }, "Auth.js warn");
     },
     debug(message, metadata) {


### PR DESCRIPTION
## Summary
- suppress the Auth.js `experimental-webauthn` warning in the NextAuth logger so it no longer floods logs when passkeys are enabled

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf7a108bfc8323ad3ae6158c612fb4