### PR TITLE
refactor: remove class variance authority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@trpc/client": "^11.0.0",
         "@trpc/react-query": "^11.0.0",
         "@trpc/server": "^11.0.0",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^16.6.1",
         "html-to-image": "^1.11.13",
@@ -5728,18 +5727,6 @@
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
-      }
-    },
-    "node_modules/class-variance-authority": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/classcat": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",
     "@trpc/server": "^11.0.0",
-    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^16.6.1",
     "html-to-image": "^1.11.13",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,31 +1,32 @@
 import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
+
 import { cn } from "@/lib/utils";
 
-const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors",
-  {
-    variants: {
-      variant: {
-        default: "border-transparent bg-white/10 text-[var(--color-text-primary)]",
-        secondary: "border-transparent bg-[var(--color-surface-elevated)] text-[var(--color-text-secondary)]",
-        outline: "border-[var(--color-border)] text-[var(--color-text-secondary)]",
-        glass: "glass text-[var(--color-text-primary)]",
-        success: "border-transparent bg-[var(--status-success-bg)] text-[var(--status-success-fg)]",
-        warning: "border-transparent bg-[var(--status-warn-bg)] text-[var(--status-warn-fg)]",
-        error: "border-transparent bg-[var(--status-error-bg)] text-[var(--status-error-fg)]",
-        info: "border-transparent bg-[var(--status-info-bg)] text-[var(--status-info-fg)]",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-);
+const badgeBaseClasses =
+  "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors";
 
-export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+const badgeVariantClasses = {
+  default: "border-transparent bg-white/10 text-[var(--color-text-primary)]",
+  secondary:
+    "border-transparent bg-[var(--color-surface-elevated)] text-[var(--color-text-secondary)]",
+  outline: "border-[var(--color-border)] text-[var(--color-text-secondary)]",
+  glass: "glass text-[var(--color-text-primary)]",
+  success:
+    "border-transparent bg-[var(--status-success-bg)] text-[var(--status-success-fg)]",
+  warning:
+    "border-transparent bg-[var(--status-warn-bg)] text-[var(--status-warn-fg)]",
+  error: "border-transparent bg-[var(--status-error-bg)] text-[var(--status-error-fg)]",
+  info: "border-transparent bg-[var(--status-info-bg)] text-[var(--status-info-fg)]",
+} as const;
+
+type BadgeVariant = keyof typeof badgeVariantClasses;
+
+const badgeVariants = ({ variant }: { variant?: BadgeVariant } = {}) =>
+  cn(badgeBaseClasses, badgeVariantClasses[variant ?? "default"]);
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: BadgeVariant;
+}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (


### PR DESCRIPTION
## Summary
- replace the badge variant helper with a simple variant map so we no longer depend on class-variance-authority
- remove the class-variance-authority package from the manifest and lockfile

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d24643190083239d1cfe30f73a50b2