### PR TITLE
chore: Bump docker tag

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
 
   rtap-web:
-    image: ghcr.io/initstring/rtap:v0.4.2
+    image: ghcr.io/initstring/rtap:v0.4.3
     container_name: rtap-web
     depends_on:
       - rtap-postgres


### PR DESCRIPTION
This PR bumps the docker-compose tag in prep for a new release.